### PR TITLE
design: 탑 버튼, 지도 버튼을 위한 레이아웃 코드 추가 (#22)

### DIFF
--- a/src/components/common/layout/Layout/Layout.jsx
+++ b/src/components/common/layout/Layout/Layout.jsx
@@ -2,13 +2,37 @@ import React from 'react';
 import styled from 'styled-components';
 import Footer from '../../Footer/Footer';
 import Header from '../../Header/Header';
+import mapIcon from '../../../../assets/images/map-icon.svg';
+import chevronIcon from '../../../../assets/images/chevron-icon.svg';
 
-const Layout = ({ children }) => {
+// 사이드 버튼은 default로 true이며, 사이드 버튼이 필요없는 페이지는 false로 사용
+const Layout = ({ children, sideButton = true }) => {
+  // 지도 버튼 기능
+  const Map = () => {
+    console.log('지도 기능이 들어갈 곳입니다.');
+  };
+
+  // 탑 버튼 기능
+  const scrollToTop = () => {
+    window.scroll({
+      top: 0,
+      behavior: 'instant',
+    });
+  };
+
   return (
     <>
       <MainContainer>
         <Header />
         <SubContainer>{children}</SubContainer>
+        {sideButton ? (
+          <>
+            <MapButton type='button' onClick={Map}></MapButton>
+            <TopButton type='button' onClick={scrollToTop}></TopButton>
+          </>
+        ) : (
+          <></>
+        )}
       </MainContainer>
       <Footer />
     </>
@@ -28,4 +52,24 @@ const SubContainer = styled.div`
   display: flex;
   flex-direction: column;
   min-height: calc(100vh - 38rem);
+`;
+
+const MapButton = styled.button`
+  position: fixed;
+  bottom: 12.8rem;
+  right: 3.2rem;
+  width: 5rem;
+  height: 5rem;
+  border-radius: 50%;
+  border: 1px solid var(--sub-text-color);
+  background: ${`url(${mapIcon})`} no-repeat center/65% #ffffff;
+  box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.15);
+  &:hover {
+    box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.3);
+  }
+`;
+
+const TopButton = styled(MapButton)`
+  bottom: 6.4rem;
+  background: ${`url(${chevronIcon})`} no-repeat center 4px #ffffff;
 `;


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 코드를 추가 / 변경한 이유
- 탑 버튼, 지도 버튼이 추가 되었습니다.
- 지도 기능은 곧 추가될 예정입니다.
- 레이아웃에 props로 사이드 버튼의 유/무를 컨트롤할 수 있습니다. (관련 주석 파일에 작성됨)


## 스크린샷 


## 관련 이슈 번호
close : #22

