### PR TITLE
feat: 응답받는 각 게시물의 createdAt 시간 보정을 위한 커스텀 훅 추가 및 적용 (#67)

### DIFF
--- a/src/components/common/Header/Header.jsx
+++ b/src/components/common/Header/Header.jsx
@@ -91,7 +91,7 @@ const Header = () => {
                       <MenuItem
                         onClick={() => {
                           toggle();
-                          navigate('/myPage');
+                          navigate('/mypage');
                         }}
                       >
                         마이페이지

--- a/src/components/common/post/Post/Post.jsx
+++ b/src/components/common/post/Post/Post.jsx
@@ -119,7 +119,6 @@ const Post = ({ profileImage, nickname, bookMark, content, img, like, comment, c
                   <span>1</span>
                 </CommentWrapper>
               </Container>
-              {/* <PostDateSpan>2023년 06월 28일</PostDateSpan> */}
               <PostDateSpan>{formattedDate}</PostDateSpan>
             </ContentInfo>
           </CardFront>

--- a/src/components/common/post/Post/Post.jsx
+++ b/src/components/common/post/Post/Post.jsx
@@ -8,6 +8,7 @@ import heartFillIcon from '../../../../assets/images/heart-fill-icon.svg';
 import commentIcon from '../../../../assets/images/comment-icon.svg';
 import { useNavigate } from 'react-router-dom';
 import { AuthContextStore } from '../../../../context/AuthContext';
+import useFormattedDate from './../../../../hooks/useFormattedDate';
 
 const Post = ({ profileImage, nickname, bookMark, content, img, like, comment, createdAt, postId, introduction }) => {
   const { userId } = useContext(AuthContextStore);
@@ -40,6 +41,9 @@ const Post = ({ profileImage, nickname, bookMark, content, img, like, comment, c
   const onClickFlipCardHandler = () => {
     setIsFlipped(!isFlipped);
   };
+
+  // 서버의 createdAt 형식 변환을 위한 커스텀 훅 사용 useFormattedDate
+  const formattedDate = useFormattedDate(createdAt);
 
   return (
     <>
@@ -115,7 +119,8 @@ const Post = ({ profileImage, nickname, bookMark, content, img, like, comment, c
                   <span>1</span>
                 </CommentWrapper>
               </Container>
-              <PostDateSpan>2023년 06월 28일</PostDateSpan>
+              {/* <PostDateSpan>2023년 06월 28일</PostDateSpan> */}
+              <PostDateSpan>{formattedDate}</PostDateSpan>
             </ContentInfo>
           </CardFront>
           <CardBack>

--- a/src/hooks/useFormattedDate.jsx
+++ b/src/hooks/useFormattedDate.jsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+const useFormattedDate = (createdAt) => {
+  const [formattedDate, setFormattedDate] = useState('');
+
+  useEffect(() => {
+    const currentDate = new Date();
+    const postDate = new Date(createdAt);
+    const timeDiff = Math.abs(currentDate - postDate);
+    const minutesDiff = Math.floor(timeDiff / (1000 * 60));
+    const hoursDiff = Math.floor(timeDiff / (1000 * 60 * 60));
+
+    if (minutesDiff < 60) {
+      setFormattedDate(`${minutesDiff}분 전`);
+    } else if (hoursDiff < 24) {
+      setFormattedDate(`${hoursDiff}시간 전`);
+    } else {
+      const options = { year: 'numeric', month: 'long', day: 'numeric' };
+      setFormattedDate(postDate.toLocaleDateString('ko-KR', options));
+    }
+  }, [createdAt]);
+
+  return formattedDate;
+};
+
+export default useFormattedDate;

--- a/src/pages/postPage/postDetailPage/PostContent/PostContent.jsx
+++ b/src/pages/postPage/postDetailPage/PostContent/PostContent.jsx
@@ -11,6 +11,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { AuthContextStore } from './../../../../context/AuthContext';
 import useModal from '../../../../hooks/useModal';
 import ProfileModal from '../../../../components/common/modal/Modal/ProfileModal/ProfileModal';
+import useFormattedDate from '../../../../hooks/useFormattedDate';
 
 const PostContent = ({
   profileImage,
@@ -52,6 +53,9 @@ const PostContent = ({
 
   // useModal
   const [modalOpen, toggle, firstRef, secondRef] = useModal();
+
+  // 서버의 createdAt 형식 변환을 위한 커스텀 훅 사용 useFormattedDate
+  const formattedDate = useFormattedDate(createdAt);
 
   return (
     <>
@@ -132,7 +136,7 @@ const PostContent = ({
               <span>1</span>
             </CommentWrapper>
           </Container>
-          <PostDateSpan>2023년 06월 28일</PostDateSpan>
+          <PostDateSpan>{formattedDate}</PostDateSpan>
         </ContentInfo>
       </Article>
     </>

--- a/src/pages/postPage/postDetailPage/PostDetailPage.jsx
+++ b/src/pages/postPage/postDetailPage/PostDetailPage.jsx
@@ -56,7 +56,7 @@ const PostDetailPage = () => {
               img={postContent.img}
               like={''}
               comment={''}
-              createdAt={''}
+              createdAt={postContent.createdAt}
               postUserId={postContent.user._id}
             />
             <PostComment profileImage={''} nickname={'익명'} comment={'댓글 테스트'} createdAt={'2023년 06월 28일'} />


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 코드를 추가 / 변경한 이유
- 각 페이지에서 응답받는 게시물들의 createdAt 시간의 보정(+09:00)이 필요했었습니다.
- 게시된 지 24시간 이내라면, ex) 12분 전, 16시간 전처럼 표시하도록 하였습니다.


## 스크린샷 


## 관련 이슈 번호
close : #67 

