### PR TITLE
design: 관광지 페이지 추가 (#84) 

### DIFF
--- a/src/components/common/Header/Header.jsx
+++ b/src/components/common/Header/Header.jsx
@@ -62,14 +62,7 @@ const Header = () => {
           <Nav>
             <Ul>
               <Li>
-                <Link
-                  to='/'
-                  onClick={() => {
-                    alert('준비 중입니다.');
-                  }}
-                >
-                  관광지
-                </Link>
+                <Link to='/tour'>관광지</Link>
               </Li>
               <Li>
                 <Link

--- a/src/components/routes/Router.jsx
+++ b/src/components/routes/Router.jsx
@@ -14,6 +14,8 @@ import PostDetailPage from '../../pages/postPage/postDetailPage/PostDetailPage';
 import ProgileSettingsPage from '../../pages/ProfileSettingsPage/ProgileSettingsPage';
 import NotFoundPage from '../../pages/NotFoundPage/NotFoundPage';
 import Mypage from '../../pages/myPage/MyPage/Mypage';
+import TouristAttractionMainPage from '../../pages/touristAttractionPage/TouristAttractionMainPage/TouristAttractionMainPage';
+import TouristAttractionRegionPage from './../../pages/touristAttractionPage/TouristAttractionRegionPage/TouristAttractionRegionPage';
 
 const Router = () => {
   const { userId } = useContext(AuthContextStore);
@@ -23,6 +25,8 @@ const Router = () => {
       <Route path='*' element={<NotFoundPage />} />
       <Route path='/notfound' element={<NotFoundPage />} />
       <Route path='/' element={<HomePage />} />
+      <Route path='/tour' element={<TouristAttractionMainPage />} />
+      <Route path='/tour/:region' element={<TouristAttractionRegionPage />} />
 
       <Route element={<NonAuthRoute authenticated={userId} />}>
         <Route path='/login' element={<LoginPage />} />

--- a/src/pages/touristAttractionPage/TouristAttractionMainPage/TouristAttractionMainPage.jsx
+++ b/src/pages/touristAttractionPage/TouristAttractionMainPage/TouristAttractionMainPage.jsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import InnerLayout from '../../../components/common/layout/InnerLayout/InnerLayout';
+import HeadingLayout from '../../../components/common/layout/HeadingLayout/HeadingLayout';
+import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
+
+const regions = [
+  '서울',
+  '부산',
+  '대구',
+  '인천',
+  '광주',
+  '대전',
+  '울산',
+  '경기',
+  '강원',
+  '충북',
+  '충남',
+  '전북',
+  '전남',
+  '경북',
+  '경남',
+  '제주',
+  '세종',
+];
+
+const TouristAttractionMainPage = () => {
+  const navigate = useNavigate();
+
+  const movePageHandler = (region) => {
+    console.log(`${region} 관광지 페이지로 이동!`);
+    navigate(`/tour/${region}`);
+  };
+
+  return (
+    <>
+      <InnerLayout>
+        <HeadingLayout heading='관광지' />
+        <Container>
+          {regions.map((region) => (
+            <Article
+              key={region}
+              onClick={() => {
+                movePageHandler(region);
+              }}
+            >
+              <H3>{region}</H3>
+              <Figure>
+                <RegionImg src={`https://picsum.photos/600/600/?${region}`} alt={`${region}의 이미지입니다.`} />
+                <ImgCover></ImgCover>
+              </Figure>
+            </Article>
+          ))}
+        </Container>
+      </InnerLayout>
+    </>
+  );
+};
+
+export default TouristAttractionMainPage;
+
+const Container = styled.div`
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+  margin: 5rem 0;
+`;
+
+const Article = styled.article`
+  position: relative;
+  width: 28.5rem;
+  height: 28.5rem;
+  border-radius: 2.5rem;
+  overflow: hidden;
+  box-shadow: 0px 2px 4px rgba(0, 0, 0, 0.15);
+`;
+
+const Figure = styled.figure`
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  height: 100%;
+
+  background: var(--main-bg-color);
+  transition: 0.6s;
+  cursor: pointer;
+  &:hover {
+    transform: scale(1.2);
+  }
+`;
+
+const H3 = styled.h3`
+  position: absolute;
+  top: 1.6rem;
+  left: 1.6rem;
+  font-size: var(--fs-md);
+  color: #ffffff;
+  font-weight: 500;
+  z-index: 100;
+`;
+
+const RegionImg = styled.img`
+  border-radius: 2.5rem;
+`;
+
+const ImgCover = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(rgb(81, 81, 81) 0%, rgba(81, 81, 81, 0) 50%);
+`;

--- a/src/pages/touristAttractionPage/TouristAttractionRegionPage/TouristAttractionRegionPage.jsx
+++ b/src/pages/touristAttractionPage/TouristAttractionRegionPage/TouristAttractionRegionPage.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import InnerLayout from '../../../components/common/layout/InnerLayout/InnerLayout';
+import HeadingLayout from '../../../components/common/layout/HeadingLayout/HeadingLayout';
+import { useParams } from 'react-router-dom';
+
+const TouristAttractionRegionPage = () => {
+  const { region } = useParams();
+
+  return (
+    <>
+      <InnerLayout>
+        <HeadingLayout
+          heading={
+            <span>
+              <strong style={{ color: '#577fa0' }}>{`${region} `}</strong>
+              관광지
+            </span>
+          }
+        />
+      </InnerLayout>
+    </>
+  );
+};
+
+export default TouristAttractionRegionPage;


### PR DESCRIPTION
## PR 타입
- [ ] 기능 추가
- [x] 스타일
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 버그 수정
- [ ] 기타


## 코드를 추가 / 변경한 이유
- 관광지 메인 페이지를 추가했습니다.
- 해당 지역의 관광지 페이지를 추가했습니다.
- 각 지역의 대표 이미지에 대한 고찰이 필요합니다. (어떤 이미지를 보여줄지? 어떻게 보여줄지?)
- 해당 지역의 각 관광지 별로 상세 페이지가 추가될 예정입니다.


## 스크린샷 


## 관련 이슈 번호
close : #84 

